### PR TITLE
Existing font and font-family support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,50 @@ For use with [object-fit-images](https://github.com/bfred-it/object-fit-images)
 }
 ```
 
+Compiles to:
+
 ```css
 .foo {
     font-family: "object-fit: cover; object-position: top";
     object-fit: cover;
     object-position: top;
+}
+```
+
+## Existing `font` and `font-family`
+
+Existing `font` and `font-family` declarations are kept and [object-fit-images](https://github.com/bfred-it/object-fit-images) will still work:
+
+```css
+.foo {
+    object-fit: cover;
+    object-position: top;
+    font-family: "Helvetica Neue";
+}
+
+/* Compiles to: */
+
+.foo {
+    object-fit: cover;
+    object-position: top;
+    font-family: "object-fit:cover;object-position:top", "Helvetica Neue";
+}
+```
+
+```css
+.foo {
+    object-fit: cover;
+    object-position: top;
+    font: strong 1em/1.4 "Helvetica Neue";
+}
+
+/* Compiles to: */
+
+.foo {
+    object-fit: cover;
+    object-position: top;
+    font: strong 1em/1.4 "Helvetica Neue";
+    font-family: "object-fit:cover;object-position:top", "Helvetica Neue";
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   },
   "homepage": "https://github.com/mshick/postcss-object-fit-images",
   "dependencies": {
-    "postcss": "^5.0.16"
+    "parse-css-font": "^2.0.2",
+    "postcss": "^5.0.16",
+    "quote": "^0.4.0"
   },
   "devDependencies": {
     "ava": "^0.14.0",

--- a/test.js
+++ b/test.js
@@ -31,3 +31,65 @@ test('adds object-position declaration', (t) => {
         { }
     );
 });
+
+test('keeps existing font-family declaration', (t) => {
+    return run(
+        t,
+        'a{' +
+            'object-fit: cover;' +
+            'object-position: top;' +
+            'font-family: "Helvetica Neue", Helvetica, sans-serif' +
+        '}',
+        'a{' +
+            'object-fit: cover;' +
+            'object-position: top;' +
+            'font-family: ' +
+                '"object-fit:cover;object-position:top", ' +
+                '"Helvetica Neue", Helvetica, sans-serif' +
+        '}',
+        { }
+    );
+});
+
+test('keeps the last existing font-family declaration', (t) => {
+    return run(
+        t,
+        'a{' +
+            'font-family: overridden;' +
+            'object-fit: cover;' +
+            'object-position: top;' +
+            'font-family: "Helvetica Neue", Helvetica, sans-serif' +
+        '}',
+        'a{' +
+            'font-family: overridden;' +
+            'object-fit: cover;' +
+            'object-position: top;' +
+            'font-family: ' +
+                '"object-fit:cover;object-position:top", ' +
+                '"Helvetica Neue", Helvetica, sans-serif' +
+        '}',
+        { }
+    );
+});
+
+test('keeps existing font declaration', (t) => {
+    return run(
+        t,
+        'a{' +
+            'font-family: overridden;' +
+            'object-fit: cover;' +
+            'object-position: top;' +
+            'font: strong 1em/1 "Helvetica Neue", Helvetica, sans-serif' +
+        '}',
+        'a{' +
+            'font-family: overridden;' +
+            'object-fit: cover;' +
+            'object-position: top;' +
+            'font: strong 1em/1 "Helvetica Neue", Helvetica, sans-serif;' +
+            'font-family: ' +
+                '"object-fit:cover;object-position:top", ' +
+                '"Helvetica Neue", Helvetica, sans-serif' +
+        '}',
+        { }
+    );
+});


### PR DESCRIPTION
I noticed that the support that I had hoped to add in #1 wouldn't actually work if `font-family` came after `object-fit`.

`font` wouldn't be considered either.

Let me know what you think of this
