### PR TITLE
Ensure font-family declaration is not added more than once

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,12 +54,18 @@ var declWalker = function (decl) {
         }
     }
     if (fontFamily) {
-        props.value += ', ' + fontFamily;
+        fontFamily = fontFamily.split(', ').filter(function (family) {
+            return family !== props.value;
+        }).join(', ');
 
-        if (existingFont.prop === 'font') {
-            existingFont.cloneAfter(props);
-        } else {
-            existingFont.replaceWith(props);
+        if (fontFamily) {
+            props.value += ', ' + fontFamily;
+
+            if (existingFont.prop === 'font') {
+                existingFont.cloneAfter(props);
+            } else {
+                existingFont.replaceWith(props);
+            }
         }
     } else {
         decl.cloneBefore(props);


### PR DESCRIPTION
I recently ran into issues using postcss-object-fit-images on a project
where the PostCSS processing was done on LESS source files, rather than
on the compiled CSS. Since the files were being modified in place, the
font-family declaration was being added every time the tool made a pass
through the file, meaning after a few compiles we ended up with a huge
list of duplicate font-family declarations.

This PR adds a filter step, which removes the plugins own output from
the existing font family declaration, to ensure that it is never added
more than once.